### PR TITLE
fix 404 error caused by RelatedArticles

### DIFF
--- a/config/LocalSettings.php
+++ b/config/LocalSettings.php
@@ -389,6 +389,7 @@ $wgPopupsReferencePreviewsBetaFeature = false;
 
 # RelatedArticles 
 $wgRelatedArticlesFooterWhitelistedSkins = [ 'citizen' ];
+$wgRelatedArticlesUseCirrusSearchApiUrl = '/api.php';
 $wgRelatedArticlesDescriptionSource = 'wikidata';
 $wgRelatedArticlesUseCirrusSearch = true;
 $wgRelatedArticlesOnlyUseCirrusSearch = true;


### PR DESCRIPTION
In 1.39, RelatedArticles introduced a hard-coded config for the API URL (`RelatedArticlesUseCirrusSearchApiUrl` ), that broke RA for us as we use domain root for script path.

Related: [T333388](https://phabricator.wikimedia.org/T333388)