### PR TITLE
Set $sespgUseFixedTables to true

### DIFF
--- a/config/LocalSettings.php
+++ b/config/LocalSettings.php
@@ -442,6 +442,7 @@ $wgRelatedArticlesOnlyUseCirrusSearch = true;
 $smwgConfigFileDir = "/usr/local/smw";
 
 # Semantic Extra Special Properties
+$sespgUseFixedTables = true;
 $sespgEnabledPropertyList = [
 	'_USERREG',
 	'_USEREDITCNT',


### PR DESCRIPTION
As recommended from https://github.com/SemanticMediaWiki/SemanticExtraSpecialProperties/blob/master/docs/configuration.md#fixed-tables

Need to run `update.php` after so that the tables are created

EDIT: The page image property does not seem to work properly currently, perhaps this will help?