### PR TITLE
Remove Extension:ExternalData

### DIFF
--- a/.github/workflows/docker-mediawiki-image.yml
+++ b/.github/workflows/docker-mediawiki-image.yml
@@ -20,4 +20,4 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: starcitizentools/mediawiki:smw-latest,starcitizentools/mediawiki:smw-v1.4.0
+          tags: starcitizentools/mediawiki:smw-latest,starcitizentools/mediawiki:smw-v1.4.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -162,7 +162,6 @@ RUN set -eux; \
 	\
 	mv /var/www/mediawiki/extensions/Checkuser /var/www/mediawiki/extensions/CheckUser; \
 	mv /var/www/mediawiki/extensions/Dismissablesitenotice /var/www/mediawiki/extensions/DismissableSiteNotice; \
-	mv /var/www/mediawiki/extensions/Externaldata /var/www/mediawiki/extensions/ExternalData; \
 	mv /var/www/mediawiki/extensions/Nativesvghandler /var/www/mediawiki/extensions/NativeSvgHandler; \
 	mv /var/www/mediawiki/extensions/Mediasearch /var/www/mediawiki/extensions/MediaSearch; \
 	mv /var/www/mediawiki/extensions/Revisionslider /var/www/mediawiki/extensions/RevisionSlider; \

--- a/composer.local.json
+++ b/composer.local.json
@@ -120,23 +120,6 @@
                 {
                         "type": "package",
                         "package": {
-                                "name": "mediawiki/externaldata",
-                                "type": "mediawiki-extension",
-                                "version": "1.39.0",
-                                "dist": {
-                                        "url": "https://github.com/wikimedia/mediawiki-extensions-ExternalData/archive/REL1_39.zip",
-                                        "type": "zip"
-                                },
-                                "source": {
-                                        "type": "git",
-                                        "url": "https://github.com/wikimedia/mediawiki-extensions-ExternalData.git",
-                                        "reference": "REL1_39"
-                                }
-                        }
-                },
-                {
-                        "type": "package",
-                        "package": {
                                 "name": "mediawiki/graph",
                                 "type": "mediawiki-extension",
                                 "version": "1.39.0",

--- a/composer.local.json
+++ b/composer.local.json
@@ -15,7 +15,6 @@
                 "mediawiki/dismissablesitenotice": "1.39.0",
                 "mediawiki/echo": "1.39.0",
                 "mediawiki/elastica": "1.39.0",
-                "mediawiki/externaldata": "1.39.0",
                 "mediawiki/graph": "1.39.0",
                 "mediawiki/json-config": "1.39.0",
                 "mediawiki/linter": "1.39.0",

--- a/config/LocalSettings.php
+++ b/config/LocalSettings.php
@@ -248,7 +248,6 @@ wfLoadExtension( 'DynamicPageList3' );
 wfLoadExtension( 'Echo' );
 wfLoadExtension( 'Elastica' );
 wfLoadExtension( 'EmbedVideo' );
-wfLoadExtension( 'ExternalData' );
 wfLoadExtension( 'Graph' );
 wfLoadExtension( 'InputBox' );
 wfLoadExtension( 'Interwiki' );
@@ -360,13 +359,6 @@ $wgDplSettings['allowUnlimitedResults'] = true;
 
 # Echo
 $wgAllowHTMLEmail = true;
-
-# ExternalData
-# $edgCacheTable = 'ed_url_cache'; Need to run ExternalData.sql first
-# $wgHTTPTimeout = 60; Set HTTP request timeout to 60s
-$edgCacheExpireTime = 3 * 24 * 60 * 60;
-$edgAllowExternalDataFrom = array( 'https://starcitizen.tools' );
-$edgExternalValueVerbose = false;
 
 # LocalicationUpdate
 // $wgLocalisationUpdateDirectory = "$IP/cache";


### PR DESCRIPTION
It is no longer used.
It was used to retrieve live data from SCDB back in the day, and used for the featured article image for SMW.
Both use cases are replaced by SMW completely so it is no longer needed.