### PR TITLE
Pin SMW dev-master and apply in-flight fix patches

### DIFF
--- a/mediawiki/composer.json
+++ b/mediawiki/composer.json
@@ -34,7 +34,7 @@
                 "starcitizenwiki/embedvideo": "dev-master",
                 "universal-omega/dynamic-page-list4": "4.0.0",
                 "edwardspec/mediawiki-aws-s3": "dev-master",
-                "mediawiki/semantic-media-wiki": "dev-master",
+                "mediawiki/semantic-media-wiki": "dev-master#8ef677518e771c1b9b01affc53e1975921da4d0b",
                 "mediawiki/semantic-extra-special-properties": "dev-master",
                 "mediawiki/semantic-result-formats": "dev-master",
                 "mediawiki/semantic-scribunto": "dev-master",
@@ -44,14 +44,25 @@
                 "starcitizentools/short-description": "dev-main",
                 "starcitizentools/tabber-neue": "dev-main",
                 "starcitizentools/thumbro": "dev-main",
-                "weirdgloop/searchdigest": "1.43.0"
+                "weirdgloop/searchdigest": "1.43.0",
+                "cweagans/composer-patches": "^2.0"
         },
         "config": {
                 "preferred-install": {
                         "*": "source"
+                },
+                "allow-plugins": {
+                        "cweagans/composer-patches": true
                 }
         },
         "extra": {
+                "composer-exit-on-patch-failure": true,
+                "patches": {
+                        "mediawiki/semantic-media-wiki": {
+                                "PR #6782 - Fix JsonCodec round-trip in SemanticData::newFromJsonArray (parser cache thrash fix)": "https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6782.diff",
+                                "PR #6781 - Fix Property namespace disabled error": "https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6781.diff"
+                        }
+                },
                 "merge-plugin": {
                         "include": [
                                 "extensions/CheckUser/composer.json",


### PR DESCRIPTION
## Summary

- Pin `mediawiki/semantic-media-wiki` to commit `8ef6775` of `master` so the patch base stays stable.
- Add `cweagans/composer-patches` and apply two open upstream PRs:
  - **[SMW#6782](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6782)** — *Fix JsonCodec round-trip in `SemanticData::newFromJsonArray`*. Restores the `maybeDeserialize`-style helper removed in #6538. Without this, every parser cache lookup for a page with SMW data fails to deserialize (`JsonCodec::deserialize` is called twice on values that JsonCodec 4.0 already restored), is silently rejected by `ParserCache::restoreFromJson`, and the page re-parses on every view — which is what we were seeing on starcitizen.tools (every Hull B view triggered a fresh parse despite a fresh entry in Valkey).
  - **[SMW#6781](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6781)** — *Fix Property namespace disabled error*.
- `composer-exit-on-patch-failure: true` so the build hard-fails if either patch can't apply after upstream advances — surfaces drift at install time, not at runtime.

## Test plan

- [ ] `composer install` completes; both patches apply without error.
- [ ] After deploy, view a page with SMW data twice within ~10 s — embedded `<!-- Saved in parser cache ... timestamp X -->` timestamp is identical on both views (cache hit, vs. changing on every view before the fix).
- [ ] Run the Valkey diagnostics workflow (`sct-k8-config` → "Valkey Diagnostics") and confirm `evicted_keys` stays at 0 and `keyspace_hits` grows materially faster than `keyspace_misses`.

## Revert path

When upstream merges:
- PR merged → drop that entry from `extra.patches`.
- Both merged → drop the `cweagans/composer-patches` require + `allow-plugins` entry + `composer-exit-on-patch-failure` flag, and unpin `mediawiki/semantic-media-wiki` back to plain `dev-master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)