### PR TITLE
Allow cweagans/composer-patches on base composer.json

### DIFF
--- a/mediawiki/Dockerfile
+++ b/mediawiki/Dockerfile
@@ -104,6 +104,11 @@ RUN --mount=type=cache,target=/var/www/.composer/cache,uid=33,gid=33 \
 	fi; \
 	\
 	/usr/bin/composer config --no-plugins allow-plugins.composer/installers true; \
+	# composer-merge-plugin does not merge the config section, so allow-plugins
+	# entries declared in composer.local.json are ignored. Allow the patches
+	# plugin here on the base composer.json so it can run during install/update.
+	/usr/bin/composer config --no-plugins allow-plugins.cweagans/composer-patches true; \
+	/usr/bin/composer config --no-plugins allow-plugins.cweagans/composer-configurable-plugin true; \
 	\
 	# Ignore security advisories
 	/usr/bin/composer config --json audit.ignore '{"PKSA-y2cr-5h3j-g3ys": "ignored"}'; \


### PR DESCRIPTION
## Summary

CI broke after #21 landed with this error in the build:

```
cweagans/composer-patches contains a Composer plugin which is blocked by
your allow-plugins config.
```

Root cause: `wikimedia/composer-merge-plugin` does **not** merge the `config` section from `composer.local.json` into the base `composer.json`. So the `allow-plugins.cweagans/composer-patches: true` entry I added in `composer.local.json` is silently ignored, and the base file blocks the plugin.

The Dockerfile already handles this for `composer/installers` with an explicit `composer config --no-plugins allow-plugins.composer/installers true`. Mirroring that pattern for `cweagans/composer-patches` and its dependency `cweagans/composer-configurable-plugin`.

## Test plan

- [ ] Build runs through `composer install` and `composer update` without the allow-plugins error.
- [ ] Patches from `extra.patches` apply (build hard-fails via `composer-exit-on-patch-failure: true` if not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)