### PR TITLE
Replace composer-patches with SMW fork branch

### DIFF
--- a/mediawiki/Dockerfile
+++ b/mediawiki/Dockerfile
@@ -104,11 +104,6 @@ RUN --mount=type=cache,target=/var/www/.composer/cache,uid=33,gid=33 \
 	fi; \
 	\
 	/usr/bin/composer config --no-plugins allow-plugins.composer/installers true; \
-	# composer-merge-plugin does not merge the config section, so allow-plugins
-	# entries declared in composer.local.json are ignored. Allow the patches
-	# plugin here on the base composer.json so it can run during install/update.
-	/usr/bin/composer config --no-plugins allow-plugins.cweagans/composer-patches true; \
-	/usr/bin/composer config --no-plugins allow-plugins.cweagans/composer-configurable-plugin true; \
 	\
 	# Ignore security advisories
 	/usr/bin/composer config --json audit.ignore '{"PKSA-y2cr-5h3j-g3ys": "ignored"}'; \

--- a/mediawiki/composer.json
+++ b/mediawiki/composer.json
@@ -34,7 +34,7 @@
                 "starcitizenwiki/embedvideo": "dev-master",
                 "universal-omega/dynamic-page-list4": "4.0.0",
                 "edwardspec/mediawiki-aws-s3": "dev-master",
-                "mediawiki/semantic-media-wiki": "dev-master#8ef677518e771c1b9b01affc53e1975921da4d0b",
+                "mediawiki/semantic-media-wiki": "dev-sct-prod-fixes",
                 "mediawiki/semantic-extra-special-properties": "dev-master",
                 "mediawiki/semantic-result-formats": "dev-master",
                 "mediawiki/semantic-scribunto": "dev-master",
@@ -44,25 +44,14 @@
                 "starcitizentools/short-description": "dev-main",
                 "starcitizentools/tabber-neue": "dev-main",
                 "starcitizentools/thumbro": "dev-main",
-                "weirdgloop/searchdigest": "1.43.0",
-                "cweagans/composer-patches": "^2.0"
+                "weirdgloop/searchdigest": "1.43.0"
         },
         "config": {
                 "preferred-install": {
                         "*": "source"
-                },
-                "allow-plugins": {
-                        "cweagans/composer-patches": true
                 }
         },
         "extra": {
-                "composer-exit-on-patch-failure": true,
-                "patches": {
-                        "mediawiki/semantic-media-wiki": {
-                                "PR #6782 - Fix JsonCodec round-trip in SemanticData::newFromJsonArray (parser cache thrash fix)": "https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6782.diff",
-                                "PR #6781 - Fix Property namespace disabled error": "https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6781.diff"
-                        }
-                },
                 "merge-plugin": {
                         "include": [
                                 "extensions/CheckUser/composer.json",
@@ -77,6 +66,10 @@
                 }
         },
         "repositories": [
+                {
+                        "type": "vcs",
+                        "url": "https://github.com/alistair3149/SemanticMediaWiki.git"
+                },
                 {
                         "type": "package",
                         "package": {


### PR DESCRIPTION
## Summary

The `cweagans/composer-patches` v2 plugin loaded during the build but silently failed to apply the two SMW fix diffs (no "Applying patch …" output in the build log — only "Resolving patches from dependencies"). v2 is a major rewrite with different resolution semantics than v1.

For two PRs against one package, a feature branch on the fork is much simpler than the patches plugin and we sidestep the v1/v2 compatibility tar-pit entirely. Branch `sct-prod-fixes` on [alistair3149/SemanticMediaWiki](https://github.com/alistair3149/SemanticMediaWiki/tree/sct-prod-fixes) carries the two PRs cherry-picked on top of master @ `8ef6775`:

- `67202b6` Fix JsonCodec round-trip in `SemanticData::newFromJsonArray` (PR [#6782](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6782), fixes parser cache thrash)
- `863a8ec` Seed SMW namespace defaults at registration time
- `f430448` ConfigBootstrapTest: assertTrue/assertFalse for PHPCS
- `806291a` Drop NamespaceManagerTest cases for moved contract  
  *(the three above are PR [#6781](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6781), fixes Property namespace disabled error)*

Removed in this PR:
- `cweagans/composer-patches` from `require`
- `extra.patches` and `extra.composer-exit-on-patch-failure`
- `config.allow-plugins.cweagans/composer-patches` (was being silently ignored anyway since `composer-merge-plugin` does not merge the `config` section)
- The two `composer config allow-plugins.cweagans/...` lines in the Dockerfile

Added: a `vcs` `repositories` entry for the fork URL.

## Test plan

- [ ] `composer install` resolves `mediawiki/semantic-media-wiki` from the fork's `sct-prod-fixes` branch.
- [ ] After deploy, two consecutive logged-in views of an SMW page (e.g. Hull B) return identical embedded `<!-- Saved in parser cache ... timestamp X -->` timestamps (cache hit instead of re-parse).
- [ ] Re-run "Valkey Diagnostics" workflow; confirm `keyspace_hits` grows materially faster than `keyspace_misses` post-deploy.

## Revert path

When upstream merges:
- One PR merges → drop its commit(s) from `sct-prod-fixes`, rebase, force-push.
- Both merge → set `mediawiki/semantic-media-wiki` back to plain `dev-master` and remove the fork's `vcs` repository entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)