### PR TITLE
Bypass GitHub API for SMW fork vcs repository

### DIFF
--- a/mediawiki/composer.json
+++ b/mediawiki/composer.json
@@ -68,7 +68,8 @@
         "repositories": [
                 {
                         "type": "vcs",
-                        "url": "https://github.com/alistair3149/SemanticMediaWiki.git"
+                        "url": "https://github.com/alistair3149/SemanticMediaWiki.git",
+                        "no-api": true
                 },
                 {
                         "type": "package",


### PR DESCRIPTION
## Summary

After #23 merged, the build failed with:

> In AuthHelper.php line 145:
> Could not authenticate against github.com

while Composer was loading repository information for the new `vcs` entry pointing at `alistair3149/SemanticMediaWiki`. The GitHub VCS driver was hitting the GitHub API anonymously and getting rate-limited (60 req/hr per IP).

`"no-api": true` tells Composer to enumerate refs via plain `git ls-remote` and fetch `composer.json` from each ref via git directly, bypassing the GitHub API entirely. No `GITHUB_TOKEN` needed, no rate limits.

Trade-off: slightly slower per install (full ref enumeration over git rather than a single API call), but the build is already long enough that this is noise. And it's a temporary measure — once both upstream PRs merge we go back to plain `dev-master` from packagist.

## Test plan

- [ ] Build runs through composer install/update with no GitHub auth error.
- [ ] `mediawiki/semantic-media-wiki` resolves to fork's `sct-prod-fixes` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)