### PR TITLE
Switch jobrunner to Weird Gloop fork

### DIFF
--- a/jobrunner/Dockerfile
+++ b/jobrunner/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /var/www/html
 
 USER www-data
 
-RUN git clone --depth 1 https://github.com/miraheze/jobrunner-service.git mediawiki-services-jobrunner
+RUN git clone --depth 1 --branch weirdgloop/master https://github.com/weirdgloop/mediawiki-services-jobrunner.git mediawiki-services-jobrunner
 
 RUN --mount=type=cache,target=/var/www/.composer/cache,uid=33,gid=33 \
    set -eux; \


### PR DESCRIPTION
## Summary

- Switch the jobrunner image from Miraheze's `jobrunner-service` fork to Weird Gloop's `mediawiki-services-jobrunner` fork (`weirdgloop/master` branch).
- Fixes the "ERROR: Runner loop N process in slot M gave status '0'" pollution in Loki dashboards by adopting the upstream's structured single-line JSON logging path.
- Drop-in change: every config key in `jobrunner-conf.json` is still consumed by the new code.

## Why

Live wiki traffic produces hundreds of fake "errors" per hour in the jobrunner logs. Investigating, the cause is two-fold:

1. The Miraheze fork emits `ERROR: Runner loop … status '<exitcode>'` regardless of whether `<exitcode>` is 0 (success). Whenever a job's PHP child writes anything to stderr (e.g. a `PHP Warning`), the wrapper logs the result as ERROR even though the job succeeded.
2. The runJobs.php `--result=json` output is pretty-printed across many lines. Loki's `detected_level` heuristic tags every line containing `"error": null,` as `detected_level=error`.

Weird Gloop's fork replaces both with a structured logging path:

- `RedisJobService::log()` always emits a single-line JSON object with `severity`, `time`, and the caller's payload merged in.
- `JobRunnerPipeline.php` passes an associative array (`command`, `loop`, `slot`, plus `$status` fields like `exitcode`, plus `stdout` or `stderr`) instead of a concatenated string.

So each completed job produces one Loki record like:

```json
{"severity":"ERROR","time":"2026-…","command":"php …/runJobs.php --type=cirrusSearchElasticaWrite …","loop":0,"slot":1,"exitcode":0,"stdout":[…]}
```

Filtering for actual failures becomes `| json | exitcode != "0"` rather than string-matching.

Bonus improvements in this fork:

- `stream_get_contents()` instead of `fread(..., 65535)` for stdout/stderr capture — no 64KB-per-read truncation on large job output.
- Pending-counter cleanup in `JobRunnerPipeline.php` not present in WMF master.
- Actively rebased on WMF master (last sync 2026-03-11) and run in production by Weird Gloop's wiki farm.

## Compatibility

Confirmed every key in `jobrunner/jobrunner-conf.json` is still read by the Weird Gloop code:

| Field | Read? |
|---|---|
| `groups.basic.runners` | yes |
| `groups.basic.include` | yes |
| `groups.basic.low-priority` | yes |
| `limits.attempts` | yes |
| `limits.claimTTL` | yes |
| `limits.real` | yes |
| `limits.memory` | yes |
| `redis.aggregators` | yes |
| `redis.queues` | yes |
| `dispatcher` | yes |

`jobrunner.sample.json` is byte-identical between Miraheze's and Weird Gloop's repos.

## Test plan

- [ ] Build the image locally and confirm composer install succeeds against the new repo
- [ ] Deploy to the cluster and confirm jobrunner pods come up healthy
- [ ] Tail logs and confirm each job emits exactly one single-line JSON record
- [ ] Confirm `Wikimedia\Rdbms` or similar real exceptions still surface with `severity:ERROR` and `exitcode != 0`
- [ ] Update Loki saved queries to use `| json | exitcode != "0"` (separate follow-up in `sct-k8-config`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)