### PR TITLE
Add PoolCounter config to gate concurrent parses

### DIFF
--- a/mediawiki/config/LocalSettings.php
+++ b/mediawiki/config/LocalSettings.php
@@ -319,6 +319,50 @@ $wgJobBackoffThrottling["htmlCacheUpdate"] = 50;
 // $wgEnableAsyncUploads = true;
 
 /**
+ * PoolCounter
+ *
+ * Serializes concurrent renders of the same uncached page via Valkey so
+ * that a heavy template/module/SMW edit (which invalidates parser cache
+ * across hundreds or thousands of pages) doesn't cause every FPM worker
+ * to re-parse the same page in parallel.
+ *
+ * With ArticleView ACQ4ANY semantics, one worker performs the parse and
+ * waiters share the cached result instead of each running their own.
+ * On timeout or queue overflow, fastStale serves the previous (now
+ * invalidated) parser-cache copy rather than 503-ing.
+ *
+ * @see https://www.mediawiki.org/wiki/PoolCounter
+ * @see https://www.mediawiki.org/wiki/Manual:$wgPoolCounterConf
+ */
+$wgPoolCounterConf = [
+    "ArticleView" => [
+        "class" => "PoolCounterRedis",
+        "timeout" => 20,
+        "workers" => 1,
+        "maxqueue" => 8,
+        "fastStale" => true,
+        "servers" => [
+            "valkey" => "valkey-service.default.svc.cluster.local:6379",
+        ],
+        "redisConfig" => [
+            "persistent" => true,
+        ],
+    ],
+    "CirrusSearch-Search" => [
+        "class" => "PoolCounterRedis",
+        "timeout" => 8,
+        "workers" => 2,
+        "maxqueue" => 4,
+        "servers" => [
+            "valkey" => "valkey-service.default.svc.cluster.local:6379",
+        ],
+        "redisConfig" => [
+            "persistent" => true,
+        ],
+    ],
+];
+
+/**
  * Output settings
  */
 // Use HTML5 encoding with minimal escaping


### PR DESCRIPTION
## Summary
Registers `ArticleView` and `CirrusSearch-Search` under `$wgPoolCounterConf`, backed by the existing Valkey instance via `PoolCounterRedis`. Inserted as a new section in `LocalSettings.php` between the job queue config and the output settings.

## Why
On this wiki, **edits to heavy Lua modules or SMW-tracked properties are the dominant trigger of FPM saturation** (confirmed pattern). The mechanism:

1. Edit invalidates parser cache for every page that transcludes the changed module/property — frequently thousands of pages on a SMW + Scribunto wiki.
2. Each subsequent request to a cold page re-runs the full parse, including the now-cold Lua module (up to 10s of CPU each — `$wgScribuntoEngineConf["luasandbox"]["cpuLimit"] = 10`).
3. With `pm.max_children = 30` (`mediawiki/Dockerfile`), parallel re-parses of 30+ cold pages saturate FPM in seconds.
4. nginx returns 504s, clients abandon (499s), wiki is effectively down.

PoolCounter with `ACQ4ANY` semantics on `ArticleView` means **only one FPM worker runs the parse for each cold page**; up to `maxqueue` others wait, then share the cached output the moment the leader finishes. That converts an N-way thundering-herd into a single parse fanning out to N served requests. The `fastStale: true` flag means waiters whose timeout expires fall back to the (now-invalidated) stale parser-cache copy rather than 503-ing — almost always preferable to a busy page.

## Values
| Type | workers | maxqueue | timeout | fastStale | Reasoning |
|---|---|---|---|---|---|
| `ArticleView` | 1 | 8 | 20s | true | Only 30 FPM workers total; up to 9 may park per hot key (~30% of pool). 20s timeout covers slowest legit module-heavy parses with margin. |
| `CirrusSearch-Search` | 2 | 4 | 8s | (n/a) | Bot-replayed identical searches less common than page herds; tighter limits since search results aren't shareable like parsed pages. |

These are deliberately conservative starting values. If observed fallback rate is high (many users seeing stale or busy responses), loosen `maxqueue` and `timeout`.

## Test plan
- [x] CI builds and pushes the new MediaWiki image.
- [x] Update the image tag in `sct-k8-config/mediawiki/php-mediawiki.yaml`, `php-mediawiki-jobs.yaml`, and `mw-cronjob.yaml` and deploy.
- [x] Verify MediaWiki starts cleanly (no `PoolCounterRedis` class-not-found or config-parse errors in php-mediawiki container logs).
- [x] Confirm PoolCounter keys appear in Valkey under heavy load (`KEYS poolcounter:*` or watch via `MONITOR` briefly).
- [x] **Critical test**: edit a moderately-transcluded template/module on a quiet test branch and watch:
  - nginx 504 rate should NOT spike on subsequent reads of affected pages.
  - php-mediawiki CPU may briefly spike but stay below saturation.
  - Loki: should NOT see a flood of `while connecting to upstream`.
- [x] Watch Valkey memory — PoolCounter keys are small and TTL'd, but worth glancing at after first cascade.

## Caveats
- **Expands Valkey's blast radius slightly.** Valkey is already critical (sessions, parser cache backing store), but article rendering currently doesn't fail when Valkey is slow — it just gets slower. With PoolCounter, a Valkey outage means article rendering hits the error path. PoolCounter raises `PoolCounter::ERROR` on Redis failures and falls back to `PoolCounterWork::error()`, which for `ArticleView` typically serves stale cache or a 503. Manageable, but worth knowing.
- **First request to a brand-new (never-rendered) page during overflow gets a "server busy" page** instead of stale content, because `fastStale` requires a stale cache copy to exist. Acceptable edge case.
- **If an FPM worker segfaults mid-parse**, the lock sits in Valkey until TTL expires. The page is in fallback mode for that interval. Self-recovers. Worth investigating any segfault patterns (we know jobrunner has segfaulted on `refreshLinks` jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)