### PR TITLE
Add UEX API source to Apiunto

### DIFF
--- a/mediawiki/config/LocalSettings.php
+++ b/mediawiki/config/LocalSettings.php
@@ -694,6 +694,12 @@ $wgApiuntoSources = [
         "token" => "",
         "timeout" => 30,
     ],
+    "UEX" => [
+        "baseUrl" => "https://api.uexcorp.uk/2.0/",
+        "token" => getenv("UEX_APITOKEN"),
+        "timeout" => 30,
+        "cacheDuration" => 86400,
+    ],
 ];
 
 /**


### PR DESCRIPTION
## Summary

Registers the [UEX 2.0 API](https://uexcorp.space/api/documentation) (`https://api.uexcorp.uk/2.0/`) as an Apiunto source, so wiki Lua can query it via `mw.ext.Apiunto.fetch('UEX', '<endpoint>', { ...params })`.

No Apiunto code change is needed — the fork already sends `Authorization: Bearer <token>` whenever a source's `token` is non-empty, which is exactly UEX 2.0's auth scheme.

## Config added (`mediawiki/config/LocalSettings.php`)

```php
"UEX" => [
    "baseUrl" => "https://api.uexcorp.uk/2.0/",
    "token" => getenv("UEX_APITOKEN"),
    "timeout" => 30,
    "cacheDuration" => 86400,
],
```

- **`token`** reads the `UEX_APITOKEN` runtime env var, following the `CLOUDFLARE_APITOKEN` precedent — never committed.
- **`cacheDuration` = 24h**, suited to UEX's mostly-static reference data (ships, items, locations) and comfortably within UEX's rate limit (120 req/min, 172.8k/day).

## Required out-of-repo step ⚠️

`UEX_APITOKEN` must be added to the runtime environment/secrets in the deploy (k8s) setup. Until it's set, the source stays inert (empty token → no auth header → UEX returns 401).

## Note for template authors

A template that fans out one `fetch` per row can burst past 120 req/min on a cold cache during a mass purge. The WAN cache absorbs repeat calls, but design per-row loops with that in mind.