### PR TITLE
Publish images to GHCR (replace Docker Hub)

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "REGISTRY" {
-  default = "docker.io"
+  default = "ghcr.io"
 }
 
 variable "TAG" {


### PR DESCRIPTION
## What

Point the build output at **GitHub Container Registry** instead of Docker Hub. One-line change: `REGISTRY` default `docker.io` → `ghcr.io`.

Resulting tags per build (`TAG` = calver):
- `ghcr.io/starcitizentools/mediawiki:smw-latest` / `:smw-<TAG>`
- `ghcr.io/starcitizentools/mediawiki:smw-jobrunner-latest` / `:smw-jobrunner-<TAG>`
- `ghcr.io/starcitizentools/nginx:latest` / `:<TAG>`

GHCR login and the registry build cache were already configured in the workflow, so no workflow change is needed (`packages: write` is already granted).

## Why

On the cluster, pulls of our own images go through Docker Hub's **anonymous per-IP rate limit**. A cold pull of a freshly bumped image was throttled to ~25 min, exceeding the deploy's rollout timeout and failing the deploy with the DB down (see the sct-k8-config incident). Our app images are the highest-volume pulls (a new tag every deploy), so moving them off Docker Hub removes the bulk of that pressure. GHCR public images have no comparable anonymous pull cap.

**Performance note:** no runtime difference (identical image bits) and pull bandwidth is comparable — the win is eliminating rate-limit *throttling*, not raw speed.

## Cutover (no dual-push)

Tags referenced in sct-k8-config are explicit (not `:latest`), so existing prod keeps running on the already-published Docker Hub tags until the manifests are repointed. Coordinate:
1. **This PR** — builds now publish to GHCR only.
2. Make the new `mediawiki` and `nginx` GHCR packages **public** (they default to private).
3. Follow-up in **sct-k8-config** — repoint `starcitizentools/*` image refs to `ghcr.io/...` (bumping to a tag that exists on GHCR).

## ⚠️ Required manual step after first GHCR push

New GHCR packages default to **private**. Set `mediawiki` and `nginx` to **public** under the org's Packages settings before sct-k8-config pulls them (or they'll need a GHCR `imagePullSecret`). The existing `sct-docker-images-cache` package is unaffected.